### PR TITLE
update example of importing AmberfloMetering in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Instantiate the AmberfloMetering construct in your AWS CDK stack. Here’s an ex
 import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as sbt from '@cdklabs/sbt-aws';
-import { AmberfloMetering } from 'amberflo-metering';
+import { AmberfloMetering } from 'sbt-aws-amberflo';
 
 export class ControlPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props: any) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sbt-aws-amberflo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sbt-aws-amberflo",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@cdklabs/sbt-aws": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbt-aws-amberflo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Amberflo plugin for AWS SBT IMetering",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Context

We released the Amberflo implementation of AWS SBT IMetering.
The readme has incorrect documentation where the import statement is

`import { AmberfloMetering } from 'amberflo-metering'` 

The correct import statement is

`import { AmberfloMetering } from 'sbt-aws-amberflo'`
