### PR TITLE
refactor: use requests module for HTTP calls

### DIFF
--- a/src/metering/amberflo-metering.ts
+++ b/src/metering/amberflo-metering.ts
@@ -46,6 +46,11 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
             Stack.of(this).region
         }:017000801446:layer:AWSLambdaPowertoolsPythonV2:59`;
 
+        // https://repost.aws/questions/QUlA3-nvrmTbGpnnhE-vRf0g/python-layers-and-requests-import-module
+        const requestsModuleLayerARN = `arn:aws:lambda:${
+            Stack.of(this).region
+        }:770693421928:layer:Klayers-p312-requests:8`;
+
         /**
          * Creates the Amberflo Metering Lambda function.
          * The function is configured with the necessary environment variables,
@@ -61,6 +66,7 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
             code: lambda.Code.fromAsset(path.resolve(__dirname, '../../resources/functions')), // Path to the directory containing your Lambda function code
             layers: [
                 lambda.LayerVersion.fromLayerVersionArn(this, 'LambdaPowerTools', lambdaPowerToolsLayerARN),
+                lambda.LayerVersion.fromLayerVersionArn(this, 'requestsModule', requestsModuleLayerARN),
             ],
             environment: {
                 API_KEY_SECRET_NAME: amberfloAPIKeySecretName,


### PR DESCRIPTION
### Summary

This pull request refactors the HTTP client implementation in `metering-service.py` to utilize the requests library instead of http.client. This change simplifies the code, improves readability, and leverages advanced features provided by requests, including automatic connection pooling.

### Changes
metering-service.py - use requests module for making HTTP calls.
amberflo-metering.ts - add lambda layer for requests module.

### Benefits
- **Simplified code**: The requests library offers a more user-friendly API compared to http.client, resulting in cleaner and more maintainable code.
- **Enhanced Features**: Utilizes requests' built-in features like session management, automatic handling of query parameters, retry mechanisms and simplified error handling.
- **Connection pooling**: requests manages a pool of connections, allowing for reuse of existing connections. This reduces the overhead of establishing a new connection for each request, leading to faster response times and more efficient resource usage. In the metering application where `ingest` will be frequently called, having a connection pool is beneficial.


