### PR TITLE
feat: make amberflo api key secret parameters mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,19 @@ Here's a brief overview of how this works:
 
 1. **Deploy a SBT Project**: If you don't already have a SBT project deployed, follow [AWS SBT's tutorial](https://github.com/awslabs/sbt-aws/tree/main/docs/public) to deploy the sample `hello-cdk` project with a `ControlPlane` and `CoreApplicationPlane`.
 2. **Amberflo Account**: You need an Amberflo account for this project. If you don’t have an Amberflo account, you can sign up for one here: [Amberflo Signup](https://www.amberflo.io/aws-saas-factory).
-3. **API Key Secret**: After signing up, the Amberflo API Key must be stored as a secret in AWS Secrets Manager. The application by default expects the secret to be created with the name `AmberfloApiKey`. However, you can create a secret with your own custom name and pass it in as a parameter to AmberfloMetering.
+3. **API Key Secret**: After signing up, the Amberflo API Key must be stored as a secret in AWS Secrets Manager.
    
-   - Secret Name: The name of the secret in AWS Secrets Manager (default: AmberfloApiKey).
-   - Secret Key: The key within the secret JSON that contains the API Key (default: AmberfloApiKey).
+   - Secret Name: The name of the secret in AWS Secrets Manager.
+   - Secret KeyId: The key within the secret JSON that identifies the Amberflo API Key.
 
+   e.g. you have a secret named AmberfloApiKey in AWS Secrets manager with the following json
+
+   ```json lines
+   {"apiKey": "<api key from your amberflo account>"} 
+   ```
+   Pass the `AmberfloApiKey` to amberfloAPIKeySecretName and `apiKey` to amberfloAPIKeySecretId
+
+   
 ### 1. Install the NPM Package
 
 Within your SBT project directory, install `aws-sbt-amberflo` via the following command:
@@ -84,8 +92,8 @@ export class ControlPlaneStack extends Stack {
     super(scope, id, props);
 
     const amberfloMetering = new AmberfloMetering(this, 'AmberfloMetering', {
-      amberfloAPIKeySecretName: 'YourSecretName', // Default is 'AmberfloApiKey'
-      amberfloAPIKeySecretId: 'YourSecretId', // Default is 'AmberfloApiKey'
+      amberfloAPIKeySecretName: 'YourSecretName', 
+      amberfloAPIKeySecretId: 'YourSecretKeyId', 
     });
 
     const controlPlane = new sbt.ControlPlane(this, 'ControlPlane', {
@@ -97,11 +105,11 @@ export class ControlPlaneStack extends Stack {
 
 #### Amberflo Metering Properties
 
-| Property Name | Type | Required | Description | Default Value |
-|:-------------|:-----|:---------|:------------|:--------------|
-| amberfloAPIKeySecretName | string | Optional | The name of the AWS Secrets Manager secret. | AmberfloApiKey |
-| amberfloAPIKeySecretId | string | Optional | The key within the secret that identifies the Amberflo API Key. | AmberfloApiKey |
-| amberfloBaseUrl | string | Optional | The base URL for Amberflo's API. | https://app.amberflo.io |
+| Property Name | Type | Required | Description                                                     | Default Value |
+|:-------------|:-----|:---------|:----------------------------------------------------------------|:--------------|
+| amberfloAPIKeySecretName | string | Yes      | The name of the AWS Secrets Manager secret.                     |  |
+| amberfloAPIKeySecretId | string | Yes      | The key within the secret that identifies the Amberflo API Key. |  |
+| amberfloBaseUrl | string | Optional | The base URL for Amberflo's API.                                | https://app.amberflo.io |
 
 ### 3. Provision a Meter
 Once you deploy your updated stack, you can create and manage meters using the provided API endpoints. Here’s how you can create a meter:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbt-aws-amberflo",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Amberflo plugin for AWS SBT IMetering",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/metering/amberflo-metering.ts
+++ b/src/metering/amberflo-metering.ts
@@ -10,13 +10,13 @@ export interface AmberfloMeteringProps {
      * The name of the AWS Secrets Manager secret that contains the Amberflo API Key.
      * This is the identifier for the secret in Secrets Manager.
      */
-    readonly amberfloAPIKeySecretName?: string
+    readonly amberfloAPIKeySecretName: string
 
     /**
      * The key within the AWS Secrets Manager secret that identifies the Amberflo API Key.
      * This is the field name within the JSON structure of the secret.
      */
-    readonly amberfloAPIKeySecretId?: string
+    readonly amberfloAPIKeySecretId: string
 
     /**
      * Amberflo base url
@@ -37,8 +37,6 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
     constructor(scope: Construct, id: string, props: AmberfloMeteringProps) {
         super(scope, id);
 
-        const amberfloAPIKeySecretName = props.amberfloAPIKeySecretName || 'AmberfloApiKey';
-        const amberfloAPIKeySecretId = props.amberfloAPIKeySecretId || 'AmberfloApiKey';
         const amberfloBaseUrl = props.amberfloBaseUrl || 'https://app.amberflo.io';
 
         // https://docs.powertools.aws.dev/lambda/python/2.31.0/#lambda-layer
@@ -69,8 +67,8 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
                 lambda.LayerVersion.fromLayerVersionArn(this, 'requestsModule', requestsModuleLayerARN),
             ],
             environment: {
-                API_KEY_SECRET_NAME: amberfloAPIKeySecretName,
-                API_KEY_SECRET_ID: amberfloAPIKeySecretId,
+                API_KEY_SECRET_NAME: props.amberfloAPIKeySecretName,
+                API_KEY_SECRET_ID: props.amberfloAPIKeySecretId,
                 AMBERFLO_BASE_URL: amberfloBaseUrl,
             },
         });
@@ -83,7 +81,7 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
         };
 
         // grant permission to read amberfloAPIKey secret
-        const amberfloApiKeySecret = secretsmanager.Secret.fromSecretNameV2(this, 'AmberfloApiKeySecret', amberfloAPIKeySecretName);
+        const amberfloApiKeySecret = secretsmanager.Secret.fromSecretNameV2(this, 'AmberfloApiKeySecret', props.amberfloAPIKeySecretName);
         amberfloApiKeySecret.grantRead(meteringService);
 
         this.createMeterFunction = meteringSyncFunction;


### PR DESCRIPTION
### Summary

This update modifies the Amberflo SBT plugin `AmberfloMetering` to require the AWS secret name and secret id for `amberfloAPIKeySecretName` and `amberfloAPIKeySecretId` as a mandatory parameter. Previously, while clients could technically specify a secret name, it was optional, and the plugin defaulted to using `AmberfloApiKey`. This could lead to runtime issues if clients did not create a secret or if clients did not create a secret with that exact name.

### Breaking Change
- The amberfloAPIKeySecretName and  amberfloAPIKeySecretId parameter are now mandatory. Clients must provide these parameter when using the AmberfloMetering construct.
- Existing implementations that do not specify a secret name will encounter runtime errors.

### Migration notes
Clients must update their implementations to pass the mandatory parameters when creating AmberfloMetering construct.
```
const amberfloMetering = new AmberfloMetering(this, 'AmberfloMetering', {
      amberfloAPIKeySecretName: 'YourSecretName', 
      amberfloAPIKeySecretId: 'YourSecretKeyId', 
});
```

### Version Update
- Version bumped from `1.0.1` to `2.0.0` to reflect this breaking change.


