### PR TITLE
add tag to the amberflo metering construct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbt-aws-amberflo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Amberflo plugin for AWS SBT IMetering",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/metering/amberflo-metering.ts
+++ b/src/metering/amberflo-metering.ts
@@ -36,6 +36,7 @@ export class AmberfloMetering extends Construct implements sbt.IMetering {
 
     constructor(scope: Construct, id: string, props: AmberfloMeteringProps) {
         super(scope, id);
+        sbt.addTemplateTag(this, 'AmberfloMetering');
 
         const amberfloBaseUrl = props.amberfloBaseUrl || 'https://app.amberflo.io';
 


### PR DESCRIPTION
### Summary

This pull request adds a tag to the Amberflo metering construct to improve resource organization and identification within AWS environment.

### Changes Made
- Added a tag to the Amberflo metering construct.
- Bumped the version to 2.0.1